### PR TITLE
Fix warning about peerDependencies with gatsby v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "react": "^15.6.1"
   },
   "peerDependencies": {
-    "gatsby": "^1.0.0"
+    "gatsby": "^1.0.0 || >2.0.0-alpha"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "keywords": [
     "gatsby",
     "gatsby-plugin",
-    "yandex matrika"
+    "yandex metrika"
   ],
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "babel-preset-latest": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
-    "cross-env": "^5.1.4"
+    "cross-env": "^5.1.4",
+    "react": "^15.6.1"
   },
   "keywords": [
     "gatsby",
@@ -21,9 +22,6 @@
     "build": "babel src --out-dir . --ignore __tests__",
     "watch": "babel -w src --out-dir . --ignore __tests__",
     "prepublish": "cross-env NODE_ENV=production npm run build"
-  },
-  "dependencies": {
-    "react": "^15.6.1"
   },
   "peerDependencies": {
     "gatsby": "^1.0.0 || >2.0.0-alpha"


### PR DESCRIPTION
- Fix warning about `peerDependencies` with `gatsby@next`;
   ![image](https://user-images.githubusercontent.com/5055595/43538315-524e169a-95ca-11e8-83de-359bd004e753.png)
- fix typo in keywords of package.json;
- move `react` to `devDependencies`.