### PR TITLE
Update counter code according to recent API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ plugins: [
 ]
 ```
 
-## WebVisor 2.0
+## CDN option
 
-If you want to use WebVisor 2.0 (beta), specify `version: 2` in `gatsby-config.js` file:
+Option 'useCDN' allows to count visits from regions, where access to Yandex resources is limited. Using altetnative CDN address may decrease counter's code loading.
 
 ```javascript
 // In your gatsby-config.js
@@ -34,7 +34,7 @@ plugins: [
       trackingId: 'YOUR_YANDEX_METRIKA_TRACKING_ID',
       webvisor: true,
       trackHash: true,
-      version: 2,
+      useCDN: true,
     },
   },
 ]

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -2,8 +2,7 @@ exports.onRouteUpdate = function({ location }, pluginOptions) {
   // Don't track while developing.
   if (
     process.env.NODE_ENV === `production` &&
-    typeof window.ym !== `undefined` &&
-    typeof window.ym.hit === 'function'
+    typeof window.ym !== `undefined`
   ) {
     window.ym(pluginOptions.trackingId, 'hit', (location || {}).pathname);
   }

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,10 +1,10 @@
-exports.onRouteUpdate = function({ location }) {
+exports.onRouteUpdate = function({ location }, pluginOptions) {
   // Don't track while developing.
   if (
     process.env.NODE_ENV === `production` &&
-    typeof window.yaCounter !== `undefined` &&
-    typeof window.yaCounter.hit === 'function'
+    typeof window.ym !== `undefined` &&
+    typeof window.ym.hit === 'function'
   ) {
-    window.yaCounter.hit((location || {}).pathname);
+    window.ym(pluginOptions.trackingId, 'hit', (location || {}).pathname);
   }
 }

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,42 +1,28 @@
 import React from "react"
 
-exports.onRenderBody = ({ setPostBodyComponents }, pluginOptions) => {
+exports.onRenderBody = ({ setPreBodyComponents }, pluginOptions) => {
   if (process.env.NODE_ENV === `production`) {
-    // useBeta flag is set for metrika 2.0
-    const useBeta = pluginOptions.version && pluginOptions.version === 2;
-    const versionSuffix = useBeta ? '2' : '';
-    const metrikaSrc = `https://mc.yandex.ru/metrika/${useBeta ? 'tag' : 'watch'}.js`;
+    const metrikaSrc = pluginOptions.useCDN
+    ? `https://cdn.jsdelivr.net/npm/yandex-metrica-watch/tag.js`
+    : `https://mc.yandex.ru/metrika/tag.js`;
 
-    return setPostBodyComponents([
+    return setPreBodyComponents([
       <script
       key={`gatsby-plugin-yandex-metrika`}
       dangerouslySetInnerHTML={{
         __html: `
-(function (d, w, c) {
-    (w[c] = w[c] || []).push(function() {
-        try {
-            w.yaCounter = new Ya.Metrika${versionSuffix}({
-                id:${pluginOptions.trackingId},
-                clickmap:true,
-                trackLinks:true,
-                accurateTrackBounce:true,
-                webvisor:${pluginOptions.webvisor},
-                trackHash:${pluginOptions.trackHash}
-            });
-        } catch(e) { }
-    });
+   (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+   m[i].l=1*new Date();k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
+   (window, document, "script", ${metrikaSrc}, "ym");
 
-    var n = d.getElementsByTagName("script")[0],
-        s = d.createElement("script"),
-        f = function () { n.parentNode.insertBefore(s, n); };
-    s.type = "text/javascript";
-    s.async = true;
-    s.src = "${metrikaSrc}";
-
-    if (w.opera == "[object Opera]") {
-        d.addEventListener("DOMContentLoaded", f, false);
-    } else { f(); }
-})(document, window, "yandex_metrika_callbacks${versionSuffix}");
+   ym(${pluginOptions.trackingId}, "init", {
+        defer: true,
+        clickmap:true,
+        trackLinks:true,
+        accurateTrackBounce:true,
+        webvisor:${pluginOptions.webvisor},
+        trackHash:${pluginOptions.trackHash}
+   });
 `,}} />,
       <noscript><div><img src={`https://mc.yandex.ru/watch/${pluginOptions.trackingId}`} style={{position:'absolute',left:'-9999px'}} alt="" /></div></noscript>
     ])


### PR DESCRIPTION
This pr should fix #6 

- Counter's code is updated
- Added new option 'useCDN', which is available in Yandex Metrics counter settings page.
- Removed code detecting beta since it is current API now.
- Updated readme file, where removed description about beta and webvisor and aded description about CDN setting.
- 'setPreBodyComponents' function is used instead of 'setPostBodyComponents' is used since it is recommended to place code after opening body tag.
