### PR TITLE
Add quotes around source url

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -13,7 +13,7 @@ exports.onRenderBody = ({ setPreBodyComponents }, pluginOptions) => {
         __html: `
    (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
    m[i].l=1*new Date();k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
-   (window, document, "script", ${metrikaSrc}, "ym");
+   (window, document, "script", "${metrikaSrc}", "ym");
 
    ym(${pluginOptions.trackingId}, "init", {
         defer: true,


### PR DESCRIPTION
While testing updated plugin, counter's script gave syntax error.
![Screenshot 2020-02-18 at 10 04 45](https://user-images.githubusercontent.com/17482985/74716035-756cd600-5236-11ea-9092-7add2d521413.png)

 I've checked transpiled code and noticed, there is no quotes around url. I updated source code and tested that it transpiles correctly.

Here how it is in master: 
![Screenshot 2020-02-18 at 9 48 26](https://user-images.githubusercontent.com/17482985/74716127-a4834780-5236-11ea-9ab4-601f89926eac.png)

Here how it should be after this pr is merged.
![Screenshot 2020-02-18 at 9 58 14](https://user-images.githubusercontent.com/17482985/74716197-bd8bf880-5236-11ea-880c-c7665c85265f.png)

